### PR TITLE
Update pax.no.kg.json

### DIFF
--- a/whois/pax.no.kg.json
+++ b/whois/pax.no.kg.json
@@ -3,9 +3,8 @@
     "domain": "pax",
     "sld": "no.kg",
     "nameservers": [
-        "ns1.hostry.com",
-        "ns2.hostry.com",
-        "ns3.hostry.com"
+        "fns1.42.pl.",
+        "fns1.42.pl."
     ],
     "agree_to_agreements": {
         "registration_and_use_agreement": true,


### PR DESCRIPTION
The DNS of https://hostry.com is not functioning properly. Please modify it to use the recommended freedns.42.