### PR TITLE
Register gpsirera.no.kg

### DIFF
--- a/whois/gpsirera.no.kg.json
+++ b/whois/gpsirera.no.kg.json
@@ -1,0 +1,14 @@
+{
+  "registrant": "gopalparmar9118@gmail.com",
+  "domain": "gpsirera",
+  "sld": "no.kg",
+  "nameservers": [
+    "ns1.vercel-dns.com",
+    "ns2.vercel-dns.com"
+  ],
+  "agree_to_agreements": {
+    "registration_and_use_agreement": true,
+    "acceptable_use_policy": true,
+    "privacy_policy": true
+  }
+}


### PR DESCRIPTION
Domain: gpsirera.no.kg
Registrant: gopalparmar9118@gmail.com
Nameservers: ns1.vercel-dns.com, ns2.vercel-dns.com