### PR TITLE
Registration: studioascolesi.no.kg

### DIFF
--- a/whois/studioascolesi.no.kg.json
+++ b/whois/studioascolesi.no.kg.json
@@ -1,0 +1,16 @@
+{
+  "registrant": "studioascolesi@gmail.com",
+  "domain": "studioascolesi",
+  "sld": "no.kg",
+  "nameservers": [
+    "ns1.he.net",
+    "ns2.he.net",
+    "ns3.he.net",
+    "ns4.he.net"
+  ],
+  "agree_to_agreements": {
+    "registration_and_use_agreement": true,
+    "acceptable_use_policy": true,
+    "privacy_policy": true
+  }
+}


### PR DESCRIPTION
Registration request for studioascolesi.no.kg

Registrant: studioascolesi@gmail.com
Domain: studioascolesi
SLD: no.kg
Nameservers: ns1.he.net, ns2.he.net, ns3.he.net, ns4.he.net

This domain will be used for Studio Ascolesi, an Italian legal/insurance studio.